### PR TITLE
fix keyboard shortcut misfire if focused in editor

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -375,6 +375,10 @@ export function App() {
 
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent) => {
+			const isEditorFocused =
+				codeEditorRef.current?.contains(document.activeElement) ||
+				assertionsEditorRef.current?.contains(document.activeElement)
+
 			if (event.metaKey || event.ctrlKey) {
 				if (event.key === 'm') {
 					event.preventDefault()
@@ -384,7 +388,7 @@ export function App() {
 					} else if (assertionsEditorRef.current?.contains(activeElement)) {
 						toggleMaximizedEditor('assertions')
 					}
-				} else if (event.key === '/') {
+				} else if (event.key === '/' && !isEditorFocused) {
 					event.preventDefault()
 					setIsShortcutsDialogOpen(prev => !prev)
 				} else if (event.key === ',') {


### PR DESCRIPTION
## PR Checklist

If the user is focused inside an editor, when pressing the keyboard shortcut (cmd + /), the default codemirror response is to comment the current line of code. This is conflicting with the app shortcut for (cmd + /) to open the keyboard shortcuts dialog.

Closes #3 

## What is the new behavior?

When a user is focused inside an editor and presses the keyboard shortcut (cmd + /), the codemirror shortcut will take president. If the user is not focused inside an editor and presses the keyboard shortcut (cmd + /), the user will see the shortcut helper dialog.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
